### PR TITLE
Update S3 locations for compatibility with SSO.

### DIFF
--- a/TreeCoverLossAnalysis.pyt
+++ b/TreeCoverLossAnalysis.pyt
@@ -38,11 +38,11 @@ class TreeCoverLossAnalysis(object):
         descript_3 = "Non-flux model results (total area, biomass stock/density, tree cover extent, gain and loss area) are for (TCD>X)."
         self.description = descript_1 + descript_2 + descript_3
         self.canRunInBackground = False
-        self.aws_account_name = (
-            boto3.client("sts").get_caller_identity().get("Arn").split("/")[1]
+        self.aws_identity_label = (
+            boto3.client("sts").get_caller_identity().get("Arn").split("/")[-1].split("@")[0]
         )
         self.s3_in_features_prefix = "{}/{}".format(
-            self.aws_account_name, self.s3_in_folder
+            self.aws_identity_label, self.s3_in_folder
         )
 
     def getParameterInfo(self):
@@ -462,7 +462,7 @@ class TreeCoverLossAnalysis(object):
                         in_features,
                         "--output",
                         "s3://{}/{}/{}".format(
-                            self.s3_bucket, self.aws_account_name, self.s3_out_folder
+                            self.s3_bucket, self.aws_identity_label, self.s3_out_folder
                         ),
                         "--tcd",
                         str(tcd_year),
@@ -558,7 +558,7 @@ class TreeCoverLossAnalysis(object):
         response = client.run_job_flow(
             Name="Geotrellis Forest Loss Analysis",
             LogUri="s3://{}/{}/{}".format(
-                self.s3_bucket, self.aws_account_name, self.s3_log_folder
+                self.s3_bucket, self.aws_identity_label, self.s3_log_folder
             ),
             ReleaseLabel="emr-6.3.0",
             Instances=instances,

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -1,6 +1,8 @@
 # AWS resources and permissions
 
-This script depends on several resources that have been set up in WRI's AWS account and requires that the user running the script have the correct permissions.
+To use this script and ArcGIS Toolbox you must have been set up with WRI's AWS account and specifically the `ForestResearcher` Single Sign-On group.
+
+Contact a Data Lab cloud administrator to gain the necessary credentials.
 
 
 ## Permissions [in process]

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ It can take about 10-12 minutes for a cluster to acquire its resource and instal
 
 You can monitor progress directly on AWS EMR console. Final results will be stored on S3 in your user folder.
 
-`s3://wri-users/{your user name}/geotrellis/results/treecoverloss_<date_time>/`
+`s3://wri-users/{your.name}/geotrellis/results/treecoverloss_<date_time>/`
 
 ## Installation and dependencies
 


### PR DESCRIPTION
This commit changes the location where files are created and stored on S3.

Previously, for dedicated IAM users, files were stored in `s3://wri-users/<username>` where `<username>` typically looked like `wmelon` for a user with the real name "Walter Melon".

With this change, the files are stored in `s3://wri-users/<first.last>` where `<first.last>` is the base of a user's wri.org email address. So the hypothetical user Walter Melon would likely have an email address that looks like `walter.melon@wri.org` and the storage location would be `s3://wri-users/walter.melon`.

Small updates to docs to reflect this change.


This essentially usurps PR #15 


1. The ARN of an SSO-activated role looks like `arn:aws:sts::838255262149:assumed-role/AWSReservedSSO_ForestResearcher_aefcfb15995a74f7/Logan.Byers@wri.org`.
1. Splitting on `/` and taking the last element gives `Logan.Byers@wri.org`.
1. Splitting on `@` and taking the first element gives `Logan.Byers`.
