### PR TITLE
2025 TCL update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 venv
 .idea
 .xml
+TreeCoverLossAnalysis.pyt.xml

--- a/TreeCoverLossAnalysis.pyt
+++ b/TreeCoverLossAnalysis.pyt
@@ -227,7 +227,7 @@ class TreeCoverLossAnalysis(object):
             category="Spark config",
         )
 
-        jar_version.value = "2.6.18_ArcPy_flux_model_v1_4_2_with_2025_TCL"
+        jar_version.value = "2.6.18_ArcPy_2025_TCL_update_flux_model_v1_4_3"
 
         out_features = arcpy.Parameter(
             displayName="Out features",

--- a/TreeCoverLossAnalysis.pyt
+++ b/TreeCoverLossAnalysis.pyt
@@ -122,7 +122,7 @@ class TreeCoverLossAnalysis(object):
         global_peat.value = False
 
         tree_cover_loss_drivers = arcpy.Parameter(
-            displayName="Driver of tree cover loss (1km model: Sims et al. 2025, with TCL through 2024)",
+            displayName="Driver of tree cover loss (1km model: Sims et al. 2025, with TCL through 2025)",
             name="tree_cover_loss_drivers",
             datatype="GPBoolean",
             parameterType="Required",
@@ -132,7 +132,7 @@ class TreeCoverLossAnalysis(object):
         tree_cover_loss_drivers.value = False
 
         tree_cover_loss_from_fires = arcpy.Parameter(
-            displayName="Tree cover loss from fires (Tyukavina et al. 2022, updated through 2024)",
+            displayName="Tree cover loss from fires (Tyukavina et al. 2022, updated through 2025)",
             name="tree_cover_loss_from fires",
             datatype="GPBoolean",
             parameterType="Required",
@@ -142,7 +142,7 @@ class TreeCoverLossAnalysis(object):
         tree_cover_loss_from_fires.value = False
 
         is__umd_tree_cover_loss = arcpy.Parameter(
-            displayName="Presence/absence of tree cover loss (updated through 2024)",
+            displayName="Presence/absence of tree cover loss (updated through 2025)",
             name="is__umd_tree_cover_loss",
             datatype="GPBoolean",
             parameterType="Required",
@@ -172,7 +172,7 @@ class TreeCoverLossAnalysis(object):
         simple_AGB_emissions.value = False
 
         emissions_by_gas_annually = arcpy.Parameter(
-            displayName="Output timeseries of emissions from CO2, CH4, and N2O separately (from Harris et al. 2021, updated through 2024)",
+            displayName="Output timeseries of emissions from CO2, CH4, and N2O separately (from Harris et al. 2021, updated through 2025)",
             name="emissions_by_gas_annually",
             datatype="GPBoolean",
             parameterType="Required",

--- a/TreeCoverLossAnalysis.pyt
+++ b/TreeCoverLossAnalysis.pyt
@@ -227,7 +227,7 @@ class TreeCoverLossAnalysis(object):
             category="Spark config",
         )
 
-        jar_version.value = "2.4.16_ArcPy_flux_model_v1_4_2"
+        jar_version.value = "2.6.18_ArcPy_flux_model_v1_4_2_with_2025_TCL"
 
         out_features = arcpy.Parameter(
             displayName="Out features",


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
- The ArcPy client currently uses a version of the treecoverloss package that uses 2024 versions of the following datasets: TCL, TCLF, 1km drivers, and forest flux layers.

Issue Number: N/A


## What is the new behavior?
- The ArcPy client has been updated to use a version of the treecoverloss package with 2025 versions of TCL, TCLF, 1km drivers, and forest flux layers (s3://gfw-pipelines/geotrellis/jars/treecoverloss-assembly-2.6.18_ArcPy_2025_TCL_update_flux_model_v1_4_3.jar). That change has been reflected in the client's description of each dataset. 
- Checked results for three test areas (submitted through the ArcPy client) with results calculated from our CarbonFluxQA script and they match. Differences between last year's results and this year's results are within expected ranges. No missing fire emissions in AOI in overlapping TCLF continent rasters (checked an admin 1 region in Morocco - MAR.14).

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No


## Other information
